### PR TITLE
Added support for Gunicorn timeout option

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
-
 - name: Install dependencies for running mr-provisioner
   apt:
     state: present
     name: "{{item}}"
   with_items:
+    - sudo
     - ipmitool
     - python3
     - python3-pip

--- a/templates/gunicorn_settings.py.j2
+++ b/templates/gunicorn_settings.py.j2
@@ -2,3 +2,4 @@ import multiprocessing
 
 bind = "0.0.0.0:{{mr_provisioner_public_port}}"
 workers = {{gunicorn_workers|default('multiprocessing.cpu_count() * 2 + 1')}}
+timeout = {{gunicorn_timeout|default('300')}}


### PR DESCRIPTION
We had problems with uploading "large" files (27Mb) to MrP, and setting the timeout to 300s resolved our issues.

Also added sudo as a dependency for database testing (sudo -s postgres)