### PR TITLE
Fix public/bmc address incoherence

### DIFF
--- a/templates/config.ini.j2
+++ b/templates/config.ini.j2
@@ -22,7 +22,7 @@ uri = postgresql+psycopg2://{{mr_provisioner_db_user}}:{{mr_provisioner_db_pass}
 [controller]
 # URI under which the controller can be accessed from the machines being
 # provisioned.
-access_uri = http://{{mr_provisioner_bmc_addr}}:{{mr_provisioner_public_port}}
+access_uri = http://{{mr_provisioner_public_addr}}:{{mr_provisioner_public_port}}
 
 [wssubprocess]
 # Leave empty to autodetect host (i.e. use window.location.hostname)
@@ -38,5 +38,5 @@ preseed_dns =
 [dhcp]
 # externally reachable (by the machines being provisioned) address (or name)
 # of the TFTP proxy
-tftp_proxy_host = {{mr_provisioner_bmc_addr}}
+tftp_proxy_host = {{mr_provisioner_public_addr}}
 default_bootfile = {{mr_provisioner_default_bootfile}}

--- a/templates/mr-provisioner-tftp.service.j2
+++ b/templates/mr-provisioner-tftp.service.j2
@@ -5,7 +5,7 @@ After=network-online.target
 
 [Service]
 ExecStart={{mr_provisioner_path}}/bin/tftp-http-proxy \
-	-http-base-url 'http://{{mr_provisioner_public_addr}}:{{mr_provisioner_public_port}}/tftp/' -log-path '{{mr_provisioner_path}}/logs/tftp-http-proxy.log' -tftp-bind-address '{{mr_provisioner_bmc_addr}}:69'
+	-http-base-url 'http://{{mr_provisioner_public_addr}}:{{mr_provisioner_public_port}}/tftp/' -log-path '{{mr_provisioner_path}}/logs/tftp-http-proxy.log' -tftp-bind-address '{{mr_provisioner_public_addr}}:69'
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
This fixes an incoherence on the interface (bmc) the tftp listens on, and the machine being provisioned looks for the TFTP and MrP (bmc).
It should be the public interface instead.