### PR TITLE
Multiple fixes for the role

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,3 +28,16 @@ mr_provisioner_bmcs: []
 mr_provisioner_networks: []
 mr_provisioner_public_addr: "{{ hostvars[inventory_hostname]['ansible_' + mr_provisioner_public_iface]['ipv4']['address'] }}"
 mr_provisioner_bmc_addr: "{{ hostvars[inventory_hostname]['ansible_' + mr_provisioner_bmc_iface]['ipv4']['address'] }}"
+mr_provisioner_package_deps:
+  - sudo
+  - ipmitool
+  - python3
+  - python3-pip
+  - postgresql
+  - libpq-dev
+  - build-essential
+  - libssl-dev
+  - python3-virtualenv
+  - python-virtualenv
+  - python-psycopg2
+mr_provisioner_ipmitool_path: "/usr/bin/ipmitool"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,17 +4,7 @@
     state: present
     name: "{{item}}"
   with_items:
-    - sudo
-    - ipmitool
-    - python3
-    - python3-pip
-    - postgresql
-    - libpq-dev
-    - build-essential
-    - libssl-dev
-    - python3-virtualenv
-    - python-virtualenv
-    - python-psycopg2
+    - "{{mr_provisioner_package_deps}}"
 
 - name: Create required directories
   file:

--- a/templates/bootstrap-provisioner.py.j2
+++ b/templates/bootstrap-provisioner.py.j2
@@ -18,15 +18,21 @@ def main():
         kwargs.update({'reserved_net': "{{network.reserved_net}}"})
         {% endif %}
         network = Network(**kwargs)
-        db.session.add(network)
-        db.session.commit()
+        try:
+            db.session.add(network)
+            db.session.commit()
+        except:
+            pass
         {% endfor %}
 	{% if mr_provisioner_bmcs is not none %}
         {% for bmc in mr_provisioner_bmcs %}
         bmc = BMC(name="{{bmc.name}}", ip="{{bmc.ip}}", privilege_level="{{bmc.privilege_level}}", bmc_type="{{bmc_type|default('plain')}}",
                   username="{{bmc.username}}", password="{{bmc.password}}")
-        db.session.add(bmc)
-        db.session.commit()
+        try:
+            db.session.add(bmc)
+            db.session.commit()
+        except:
+            pass
 	{% endfor %}
 	{% endif %}
 

--- a/templates/config.ini.j2
+++ b/templates/config.ini.j2
@@ -14,7 +14,7 @@ netboot_templates_dir =
 max_upload_size = 1073741824
 
 [tools]
-ipmitool = /usr/bin/ipmitool
+ipmitool = {{mr_provisioner_ipmitool_path}}
 
 [database]
 uri = postgresql+psycopg2://{{mr_provisioner_db_user}}:{{mr_provisioner_db_pass}}@localhost/{{mr_provisioner_db_name}}


### PR DESCRIPTION
- Move the package dependencies into a variable, in that way
- Move the ipmitool path to a variable (Fixes: #1)
- Don't pass exceptions when a network/bmc fails to be added.