### PR TITLE
Added MrP installation from git

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 mr_provisioner_path: "/opt/mr-provisioner"
 mr_provisioner_build_path: "{{mr_provisioner_path}}/build"
 mr_provisioner_version: "0.2.8"
+mr_provisioner_fetch_git: False
 mr_provisioner_source: "https://github.com/Linaro/mr-provisioner/releases/download/v{{mr_provisioner_version}}/mr-provisioner-{{mr_provisioner_version}}.tar.gz"
 mr_provisioner_ws_subprocess_version: "0.1"
 mr_provisioner_ws_subprocess_source: "https://github.com/bwalex/ws-subprocess/releases/download/v{{mr_provisioner_ws_subprocess_version}}/ws-subprocess"

--- a/tasks/git_fetch_setup.yml
+++ b/tasks/git_fetch_setup.yml
@@ -1,0 +1,31 @@
+---
+- name: Install git, curl on MrP machine
+  apt:
+          name: "{{ item }}"
+          state: present
+  with_items:
+          - git
+          - curl
+
+- name: Run nodejs setup script
+  shell: "curl -sL https://deb.nodesource.com/setup_9.x | sudo -E bash -"
+
+- name: Install nodejs
+  apt:
+          name: nodejs
+          state: present
+
+- name: Fetch the sources from a MrP repo
+  git:
+          repo: "{{ mrp_git }}"
+          dest: "{{ mrp_build_path }}"
+          version: "{{ mrp_git_branch }}"
+
+- name: Build dist
+  shell: "cd {{ mrp_build_path }} && make dist"
+
+- name: Fetch mr-provisioner sources.
+  unarchive:
+    src: "{{ mrp_build_path }}/dist/mr-provisioner-{{ mrp_version }}.tar.gz"
+    dest: "{{mrp_dist_path}}"
+    remote_src: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,6 +32,17 @@
     remote_src: yes
   with_items:
     - "{{mr_provisioner_source}}"
+  when: not mr_provisioner_fetch_git
+
+- name: Fetch mr-provisioner sources via git.
+  include_tasks: git_fetch_setup.yml
+  vars:
+          mrp_git: "{{ mr_provisioner_git }}"
+          mrp_build_path: "{{ mr_provisioner_build_path }}/mr-provisioner-{{mr_provisioner_version}}/git"
+          mrp_dist_path: "{{mr_provisioner_build_path}}"
+          mrp_git_branch: "{{ mr_provisioner_git_branch | default('master') }}"
+          mrp_version: "{{mr_provisioner_version}}" 
+  when: mr_provisioner_fetch_git
 
 - name: Create mr-provisioner virtualenv
   pip:


### PR DESCRIPTION
Installs curl, git and nodejs, then makes distribution of MrP.
This dist is then injected into the normal installation pipeline.

Note that this is disabled by default.