### PR TITLE
Workaround backwards incompatibility of pip 10

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ mr_provisioner_ws_subprocess_source: "https://github.com/bwalex/ws-subprocess/re
 mr_provisioner_tftp_http_proxy_version: "0.3"
 mr_provisioner_tftp_http_proxy_source: "https://github.com/niedbalski/tftp-http-proxy/releases/download/v{{mr_provisioner_tftp_http_proxy_version}}/tftp-http-proxy"
 mr_provisioner_kea_plugin_version: "0.1"
+mr_provisioner_pip_version: "9.0.1"
 mr_provisioner_venv_path: "{{mr_provisioner_path}}/venv"
 mr_provisioner_config: "/etc/mr-provisioner.ini"
 mr_provisioner_banner: "test provisioner"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,7 +40,7 @@
     virtualenv_python: python3.5
 
 - name: Run mr-provisioner setup.py install
-  shell: "{{mr_provisioner_venv_path}}/bin/python -m pip install pip==9.0.1 && cd {{mr_provisioner_build_path}}/mr-provisioner-{{mr_provisioner_version}} && {{mr_provisioner_venv_path}}/bin/python setup.py install"
+  shell: "{{mr_provisioner_venv_path}}/bin/python -m pip install pip=={{mr_provisioner_pip_version}} && cd {{mr_provisioner_build_path}}/mr-provisioner-{{mr_provisioner_version}} && {{mr_provisioner_venv_path}}/bin/python setup.py install"
 
 - name: Workaround for https://github.com/Linaro/mr-provisioner/issues/71
   shell: echo "{{mr_provisioner_version}}" > "{{mr_provisioner_venv_path}}/lib/python3.5/site-packages/mr_provisioner-{{mr_provisioner_version}}-py3.5.egg/VERSION"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,7 +40,7 @@
     virtualenv_python: python3.5
 
 - name: Run mr-provisioner setup.py install
-  shell: "cd {{mr_provisioner_build_path}}/mr-provisioner-{{mr_provisioner_version}} && {{mr_provisioner_venv_path}}/bin/python setup.py install"
+  shell: "{{mr_provisioner_venv_path}}/bin/python -m pip install pip==9.0.1 && cd {{mr_provisioner_build_path}}/mr-provisioner-{{mr_provisioner_version}} && {{mr_provisioner_venv_path}}/bin/python setup.py install"
 
 - name: Workaround for https://github.com/Linaro/mr-provisioner/issues/71
   shell: echo "{{mr_provisioner_version}}" > "{{mr_provisioner_venv_path}}/lib/python3.5/site-packages/mr_provisioner-{{mr_provisioner_version}}-py3.5.egg/VERSION"


### PR DESCRIPTION
Pending on setup.py in MrP being modified/corrected, this install is broken with new virtualenv.
This works around the bug by forcing a pip downgrade to pip 9.0.1